### PR TITLE
Add initial tools and configuration files for compiling WW4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ test_format
 test_format.cpp
 
 # User-specific configuration
-compilation.yaml
+/ww4_compile_config.yml
 
 # Externals
 externals/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ verify_ww4.py
 test_format
 test_format.cpp
 
+# User-specific configuration
+compilation.yaml
+
 # Externals
 externals/*
 !externals/README.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,14 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Strict warnings and sanitizers
-if(MSVC)
-    add_compile_options(/W4 /WX)
-else()
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -fsanitize=address,undefined)
-    add_link_options(-fsanitize=address,undefined)
+# Strict warnings and sanitizers (if not overridden by CMAKE_CXX_FLAGS)
+if(NOT CMAKE_CXX_FLAGS)
+    if(MSVC)
+        add_compile_options(/W4 /WX)
+    else()
+        add_compile_options(-Wall -Wextra -Wpedantic -Werror -fsanitize=address,undefined)
+        add_link_options(-fsanitize=address,undefined)
+    endif()
 endif()
 
 # Include directories

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,28 @@
+<p align="center">
+  <img src="https://github.com/NOAA-EMC/WW4/wiki/images/WW4_banner.jpg" alt="WW4 banner" height="100">
+</p>
+
+# <p align="center"> WAVEWATCH IV<sup> TM</sup> (WW4<sup> TM</sup>) Configuration Templates </p>
+
+This directory contains template files for configuring the WAVEWATCH IV build environment. These templates provide a starting point for users to set up their local compilation environment.
+
+## Interactive usage
+
+Users can manually copy the templates from this directory to the desired location (typically the repository root) and modify them as needed.
+
+1.  Copy `templates/compilation.yaml` to the root directory:
+    ```bash
+    cp templates/compilation.yaml ./compilation.yaml
+    ```
+2.  Edit `compilation.yaml` to specify your compiler and preferred options.
+
+## Automatic usage
+
+Build scripts or CI/CD pipelines can use these templates to generate default configurations if a user-specified configuration is not found.
+
+#
+<p align="right">
+  <img src="https://github.com/NOAA-EMC/WW4/wiki/images/noaa_logo.gif" alt="NOAA Logo" height="50" ; width="55">
+  <img src="https://github.com/NOAA-EMC/WW4/wiki/images/nws.jpg" alt="NWS Logo" height="50" width="50">
+  <img src="https://github.com/NOAA-EMC/WW4/wiki/images/ncep_logo.gif" alt="NCEP Logo" height="50" width="75">
+ </p>

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,11 +10,11 @@ This directory contains template files for configuring the WAVEWATCH IV build en
 
 Users can manually copy the templates from this directory to the desired location (typically the repository root) and modify them as needed.
 
-1.  Copy `templates/compilation.yaml` to the root directory:
+1.  Copy `templates/ww4_compile_config.yml` to the root directory:
     ```bash
-    cp templates/compilation.yaml ./compilation.yaml
+    cp templates/ww4_compile_config.yml ./ww4_compile_config.yml
     ```
-2.  Edit `compilation.yaml` to specify your compiler and preferred options.
+2.  Edit `ww4_compile_config.yml` to specify your compiler and preferred options.
 
 ## Automatic usage
 

--- a/templates/compilation.yaml
+++ b/templates/compilation.yaml
@@ -1,0 +1,16 @@
+# @file compilation.yaml
+# @brief YAML template for WAVEWATCH IV (WW4) compilation configuration.
+# @copyright © 2026 National Weather Service, National Oceanic and Atmospheric Administration, U.S. Federal Government.
+# @author Aldgisl (Principal Architect, 2026-03-20)
+# @date 2026-03-20
+#
+# @details This file provides a template for configuring the compiler and
+#          compilation options for WAVEWATCH IV. Users should copy this file
+#          to the root directory and modify it according to their environment.
+
+compiler:
+  # Name of the C++ compiler (e.g., g++, clang++, icpx)
+  name: "g++"
+
+  # Compilation options/flags
+  options: "-O3 -Wall -Wextra -std=c++20"

--- a/templates/ww4_compile_config.yml
+++ b/templates/ww4_compile_config.yml
@@ -1,7 +1,7 @@
 # @file ww4_compile_config.yml
 # @brief YAML template for WAVEWATCH IV (WW4) compilation configuration.
 # @copyright © 2026 National Weather Service, National Oceanic and Atmospheric Administration, U.S. Federal Government.
-# @author Aldgisl (Principal Architect, 2026-03-20)
+# @author Aldgisl, Hendrik Tolman 
 # @date 2026-03-20
 #
 # @details This file provides a template for configuring the compiler and

--- a/templates/ww4_compile_config.yml
+++ b/templates/ww4_compile_config.yml
@@ -1,4 +1,4 @@
-# @file compilation.yaml
+# @file ww4_compile_config.yml
 # @brief YAML template for WAVEWATCH IV (WW4) compilation configuration.
 # @copyright © 2026 National Weather Service, National Oceanic and Atmospheric Administration, U.S. Federal Government.
 # @author Aldgisl (Principal Architect, 2026-03-20)

--- a/tools/ww4_compile
+++ b/tools/ww4_compile
@@ -1,0 +1,51 @@
+#!/bin/bash
+#      +--------------------------------------------------------+
+#      | WAVEWATCH IV, open source, code management by NOAA/NWS |
+#      +--------------------------------------------------------+
+#
+# @file ww4_compile
+# @brief Shell wrapper for the WAVEWATCH IV (WW4) compile tool.
+# @details This script reads the active repository clone path from
+#          ~/.ww4_config.yml and executes the underlying Python
+#          compile tool.
+#
+# @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
+#               Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
+#               of the National Weather Service.
+# @author Aldgisl (Initial, 2026-03-24)
+# @author Aldgisl (Last Update, 2026-03-24)
+# @date 2026-03-24
+
+CONFIG_FILE="$HOME/.ww4_config.yml"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: Configuration file $CONFIG_FILE not found."
+    echo "Please ensure the active clone is configured."
+    exit 1
+fi
+
+# Extract active_clone path using python3 to handle YAML safely
+ACTIVE_CLONE=$(python3 -c "import yaml
+with open('$CONFIG_FILE', 'r') as f:
+    config = yaml.safe_load(f)
+    if config and 'active_clone' in config:
+        print(config['active_clone'])" 2>/dev/null)
+
+if [ -z "$ACTIVE_CLONE" ]; then
+    echo "Error: 'active_clone' not defined in $CONFIG_FILE"
+    exit 1
+fi
+
+if [ ! -d "$ACTIVE_CLONE" ]; then
+    echo "Error: Active clone directory $ACTIVE_CLONE does not exist."
+    exit 1
+fi
+
+COMPILE_TOOL="$ACTIVE_CLONE/tools/ww4_compile.py"
+
+if [ ! -f "$COMPILE_TOOL" ]; then
+    echo "Error: Compile tool not found at $COMPILE_TOOL"
+    exit 1
+fi
+
+python3 "$COMPILE_TOOL" "$@"

--- a/tools/ww4_compile
+++ b/tools/ww4_compile
@@ -9,6 +9,19 @@
 #          ~/.ww4_config.yml and executes the underlying Python
 #          compile tool.
 #
+# Usage
+# -----
+# 1. Define the active WAVEWATCH IV repository clone in your home directory:
+#    echo "active_clone: /path/to/your/ww4/clone" > ~/.ww4_config.yml
+#
+# 2. Run the compile tool from any directory:
+#    ww4_compile [options]
+#
+# Options:
+#   --config CONFIG       Path to the compiler configuration YAML file.
+#   --build-dir BUILD_DIR Build directory (relative to repository root).
+#   --clean               Clean the build directory before building.
+#
 # @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
 #               Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
 #               of the National Weather Service.

--- a/tools/ww4_compile
+++ b/tools/ww4_compile
@@ -25,9 +25,7 @@
 # @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
 #               Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
 #               of the National Weather Service.
-# @author Aldgisl (Initial, 2026-03-24)
-# @author Aldgisl (Last Update, 2026-03-24)
-# @date 2026-03-24
+# @author Aldgisl, Henrik Tolman (Initial, 2026-03-24)
 
 CONFIG_FILE="$HOME/.ww4_config.yml"
 

--- a/tools/ww4_compile.py
+++ b/tools/ww4_compile.py
@@ -5,9 +5,34 @@
 
 @file ww4_compile.py
 @brief A CMake-based compile tool for WAVEWATCH IV (WW4).
-@details This tool uses the ww4_compile_config.yml file in the repository root
-         directory to define the compiler and the compile options, and invokes
-         CMake to build the project.
+@details This tool uses the ww4_compile_config.yml file to define the compiler
+         and the compile options, and invokes CMake to build the project.
+
+Usage
+-----
+1.  Copy the template configuration file to the repository root:
+    cp templates/ww4_compile_config.yml ./ww4_compile_config.yml
+
+2.  Edit ww4_compile_config.yml to specify your compiler and preferred options:
+    compiler:
+      name: "g++"
+      options: "-O3 -Wall -Wextra -std=c++20"
+
+3.  Run the compile tool from the repository root:
+    python3 tools/ww4_compile.py
+
+4.  Optionally specify a custom build directory or clean the previous build:
+    python3 tools/ww4_compile.py --build-dir my_build --clean
+
+Search Logic
+------------
+The tool searches for the configuration file in the following order:
+1.  The directory from which the tool is called (current working directory).
+2.  The root directory of the repository clone.
+
+If a relative path is provided via --config, it is checked in these two
+locations. If an absolute path is provided, it is used directly.
+
 @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
                Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
                of the National Weather Service.

--- a/tools/ww4_compile.py
+++ b/tools/ww4_compile.py
@@ -17,7 +17,6 @@
 """
 
 import argparse
-import os
 import subprocess
 import sys
 from pathlib import Path

--- a/tools/ww4_compile.py
+++ b/tools/ww4_compile.py
@@ -11,7 +11,9 @@
 @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
                Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
                of the National Weather Service.
-@author Aldgisl, Hendrik L. Tolman (Initial, 2026-03-20)
+@author Aldgisl (Initial, 2026-03-20)
+@author Aldgisl (Last Update, 2026-03-20)
+@date 2026-03-20
 """
 
 import argparse
@@ -113,9 +115,27 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    cwd = Path.cwd()
     root_dir = Path(__file__).parent.parent.resolve()
-    config_path = root_dir / args.config
-    build_dir = root_dir / args.build_dir
+
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        # Try current working directory first
+        cwd_config = cwd / config_path
+        # Try repository root directory second
+        root_config = root_dir / config_path
+
+        if cwd_config.exists():
+            config_path = cwd_config
+        elif root_config.exists():
+            config_path = root_config
+        else:
+            # If neither exists, fall back to cwd_config for the error message in load_config
+            config_path = cwd_config
+
+    build_dir = Path(args.build_dir)
+    if not build_dir.is_absolute():
+        build_dir = root_dir / build_dir
 
     # Load configuration
     config = load_config(config_path)

--- a/tools/ww4_compile.py
+++ b/tools/ww4_compile.py
@@ -1,0 +1,155 @@
+"""
+      +--------------------------------------------------------+
+      | WAVEWATCH IV, open source, code management by NOAA/NWS |
+      +--------------------------------------------------------+
+
+@file ww4_compile.py
+@brief A CMake-based compile tool for WAVEWATCH IV (WW4).
+@details This tool uses the ww4_compile_config.yml file in the repository root
+         directory to define the compiler and the compile options, and invokes
+         CMake to build the project.
+@copyright © 2026 National Weather Service, National Oceanic and Atmospheric
+               Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
+               of the National Weather Service.
+@author Aldgisl (Initial, 2026-03-20)
+@author Aldgisl (Last Update, 2026-03-20)
+@date 2026-03-20
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML is not installed. Please install it using 'pip install PyYAML'.")
+    sys.exit(1)
+
+
+def load_config(config_path: Path) -> Dict[str, Union[str, Dict[str, str]]]:
+    """
+    Load the compilation configuration from a YAML file.
+
+    Parameters
+    ----------
+    config_path : Path
+        The path to the ww4_compile_config.yml file.
+
+    Returns
+    -------
+    Dict[str, Union[str, Dict[str, str]]]
+        The configuration dictionary.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the configuration file does not exist.
+    yaml.YAMLError
+        If the configuration file is not a valid YAML file.
+    """
+    if not config_path.exists():
+        print(f"Error: Configuration file not found at {config_path}")
+        print("Please copy the template to the root directory:")
+        print(f"  cp templates/ww4_compile_config.yml {config_path.name}")
+        sys.exit(1)
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        try:
+            config = yaml.safe_load(f)
+            if not config or "compiler" not in config:
+                print("Error: Invalid configuration format in ww4_compile_config.yml")
+                sys.exit(1)
+            return config
+        except yaml.YAMLError as exc:
+            print(f"Error parsing {config_path}: {exc}")
+            sys.exit(1)
+
+
+def run_command(command: list[str], cwd: Optional[Path] = None) -> None:
+    """
+    Run a shell command and handle errors.
+
+    Parameters
+    ----------
+    command : list[str]
+        The command to run as a list of strings.
+    cwd : Optional[Path], optional
+        The working directory to run the command in, by default None.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the command returns a non-zero exit code.
+    """
+    print(f"Running: {' '.join(command)}")
+    try:
+        subprocess.run(command, cwd=cwd, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed with exit code {exc.returncode}")
+        sys.exit(exc.returncode)
+
+
+def main() -> None:
+    """
+    Main entry point for the WW4 compile tool.
+    """
+    parser = argparse.ArgumentParser(description="WAVEWATCH IV Compile Tool")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="ww4_compile_config.yml",
+        help="Path to the configuration file (default: ww4_compile_config.yml)",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=str,
+        default="build",
+        help="Build directory (default: build)",
+    )
+    parser.add_argument(
+        "--clean", action="store_true", help="Clean the build directory before building"
+    )
+
+    args = parser.parse_args()
+
+    root_dir = Path(__file__).parent.parent.resolve()
+    config_path = root_dir / args.config
+    build_dir = root_dir / args.build_dir
+
+    # Load configuration
+    config = load_config(config_path)
+    compiler_name = config["compiler"].get("name", "g++")
+    compiler_options = config["compiler"].get("options", "")
+
+    # Clean if requested
+    if args.clean and build_dir.exists():
+        import shutil
+
+        print(f"Cleaning build directory: {build_dir}")
+        shutil.rmtree(build_dir)
+
+    # Configure
+    configure_cmd = [
+        "cmake",
+        "-B",
+        str(build_dir),
+        "-S",
+        str(root_dir),
+        f"-DCMAKE_CXX_COMPILER={compiler_name}",
+        f"-DCMAKE_CXX_FLAGS={compiler_options}",
+    ]
+    run_command(configure_cmd)
+
+    # Build
+    build_cmd = ["cmake", "--build", str(build_dir)]
+    run_command(build_cmd)
+
+    print("\nBuild complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ww4_compile.py
+++ b/tools/ww4_compile.py
@@ -36,9 +36,7 @@ locations. If an absolute path is provided, it is used directly.
 @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
                Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
                of the National Weather Service.
-@author Aldgisl (Initial, 2026-03-20)
-@author Aldgisl (Last Update, 2026-03-20)
-@date 2026-03-20
+@author Aldgisl, Hendrik Tolman (Initial, 2026-03-20)
 """
 
 import argparse

--- a/tools/ww4_compile.py
+++ b/tools/ww4_compile.py
@@ -11,9 +11,7 @@
 @copyright © 2026 National Weather Service, National Oceanic and Atmospheric
                Administration. WAVEWATCH IV (TM) and WW4 (TM) are trademarks
                of the National Weather Service.
-@author Aldgisl (Initial, 2026-03-20)
-@author Aldgisl (Last Update, 2026-03-20)
-@date 2026-03-20
+@author Aldgisl, Hendrik L. Tolman (Initial, 2026-03-20)
 """
 
 import argparse


### PR DESCRIPTION
This PR is building the basic infrastructure for compile tools for WW4. At this point, the tools have not been fully tested as testing is easier done once configure tools have been built too (the second half of this project). The development added here was done in three steps

Step 1:

The `templates/ww4_compile_config.yaml` file provides a starting point for users to define their compiler and compilation options. A copy of this file has been placed in the root directory as `ww4_compile_config.yaml` for immediate use. Crucially, `.gitignore` has been updated to ensure that `ww4_compile_config.yaml` in the root is not tracked, allowing users to customize their local build environment without affecting the repository and vice versa.

**How this file is used:**
The `ww4_compile_config.yaml` file is designed to be parsed by build orchestration tools or scripts. For example, a Python-based build driver can read the `compiler: name` and `compiler: options` keys to dynamically configure CMake or set environment variables. This allows for a flexible and user-specific build process that is decoupled from the main version-controlled project files.

A new `templates/README.md` provides instructions for both interactive and automatic usage of these templates, adhering to the standard WAVEWATCH IV documentation style.

Step 2:

This change introduces a new Python-based compile tool (`tools/ww4_compile.py`) that uses a YAML configuration file (`ww4_compile_config.yml`) in the repository root to define the compiler and compilation options. It also updates `CMakeLists.txt` to properly handle these custom flags, ensuring they take precedence over default strict warnings and sanitizers. The tool follows the 'Aldgisl Protocol' for Modern Python and C++ development.

This update enhances the `tools/ww4_compile.py` tool by implementing a tiered search for its configuration file. It now checks the caller's current working directory first, followed by the repository's root directory. This provides greater flexibility for users running the tool from various locations. Additionally, the build directory path is now consistently resolved relative to the repository root, ensuring stable build behavior.

This update provides comprehensive documentation directly within the `tools/ww4_compile.py` script. The documentation covers essential setup steps (copying the template, editing flags), basic and advanced execution examples, and an explanation of the configuration file's tiered search logic. This enhances the tool's usability for both new and experienced developers.

Step 3:

This change adds a shell script `tools/ww4_compile` that serves as a global entry point for the WAVEWATCH IV compilation process. It dynamically resolves the path to the active repository clone using a configuration file (`~/.ww4_config.yml`) and delegates the actual build to the internal Python tool. This allows users to compile from any directory once their active clone is configured.
